### PR TITLE
Replace 'ubuntu-16.04' -> 'ubuntu-latest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Matrix Testing:
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go: [ '1.14', '1.13' ]


### PR DESCRIPTION
**Description:**
Example in README.md not working

```
Can't find any online and idle self-hosted runner in the current repository, account/organization that matches the required labels: 'ubuntu-16.04'
```

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.